### PR TITLE
New configuration settings are in a Configuration class, additional docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,16 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+```
+elasticsearch:
+  url: "http://localhost:9200/" # Required. Supports auth and SSL: https://user:pass@someurl.com
+                                # Can also read URLs stored in environment variable named
+                                # BONSAI_URL and ELASTICSEARCH_URL.
+  number_of_shards: 1           # Optional. Default is 1 primary shard.
+  number_of_replicas: 1         # Optional. Default is 0 replicas.
+  index_name: "jekyll"          # Optional. Default is "jekyll".
+  default_type: "post"          # Optional. Default type is "post".
+```
 
 ## Development
 
@@ -33,4 +42,3 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/searchyou.
-

--- a/lib/searchyou/configuration.rb
+++ b/lib/searchyou/configuration.rb
@@ -1,0 +1,35 @@
+module Searchyou
+  class Configuration
+    attr_accessor :site
+    def initialize(site)
+      self.site = site
+    end
+
+    # Determine a URL for the cluster, or fail with error
+    def elasticsearch_url
+      ENV['BONSAI_URL'] || ENV['ELASTICSEARCH_URL'] ||
+        ((site.config||{})['elasticsearch']||{})['url'] ||
+        raise(ArgumentError, "No Elasticsearch URL present, skipping indexing")
+    end
+
+    # Getter for the number of primary shards
+    def elasticsearch_number_of_shards
+      site.config['elasticsearch']['number_of_shards'] || 1
+    end
+
+    # Getter for the number of replicas
+    def elasticsearch_number_of_replicas
+      site.config['elasticsearch']['number_of_replicas'] || 1
+    end
+
+    # Getter for the index name
+    def elasticsearch_index_base_name
+      site.config['elasticsearch']['index_name'] || "jekyll"
+    end
+
+    # Getter for the default type
+    def elasticsearch_default_type
+      site.config['elasticsearch']['default_type'] || 'post'
+    end
+  end
+end

--- a/lib/searchyou/generator.rb
+++ b/lib/searchyou/generator.rb
@@ -1,4 +1,5 @@
 require 'searchyou/indexer'
+require 'searchyou/configuration'
 
 module Searchyou
 
@@ -38,38 +39,4 @@ module Searchyou
 
   end
 
-  # Class containing configuration options
-  class Configuration
-    attr_accessor :site
-    def initialize(site)
-      self.site = site
-    end
-
-    # Determine a URL for the cluster, or fail with error
-    def elasticsearch_url
-      ENV['BONSAI_URL'] || ENV['ELASTICSEARCH_URL'] ||
-        ((site.config||{})['elasticsearch']||{})['url'] ||
-        raise(ArgumentError, "No Elasticsearch URL present, skipping indexing")
-    end
-
-    # Getter for the number of primary shards
-    def elasticsearch_number_of_shards
-      site.config['elasticsearch']['number_of_shards'] || 1
-    end
-
-    # Getter for the number of replicas
-    def elasticsearch_number_of_replicas
-      site.config['elasticsearch']['number_of_replicas'] || 1
-    end
-
-    # Getter for the index name
-    def elasticsearch_index_base_name
-      site.config['elasticsearch']['index_name'] || "jekyll"
-    end
-
-    # Getter for the default type
-    def elasticsearch_default_type
-      site.config['elasticsearch']['default_type'] || 'post'
-    end
-  end
 end

--- a/lib/searchyou/generator.rb
+++ b/lib/searchyou/generator.rb
@@ -19,7 +19,7 @@ module Searchyou
       Searchyou.configure(site)
 
       # Prepare the indexer
-      indexer = Searchyou::Indexer.new(Searchyou.configuration.url)
+      indexer = Searchyou::Indexer.new(Searchyou.configuration)
       indexer.start
 
       # Iterate through the site contents and send to indexer
@@ -48,23 +48,11 @@ module Searchyou
     self.configuration ||= Configuration.new(site)
   end
 
+  # Class containing configuration options
   class Configuration
-    attr_accessor :url, :number_of_shards, :number_of_replicas, :index_name, :default_type
-
+    attr_accessor :site
     def initialize(site)
-
-      # Figure out the Elasticsearch URL, from an environment variable or the
-      # Jekyll site configuration. Raises an exception if none is found, so we
-      # can skip the indexing.
-      @url = ENV['BONSAI_URL'] || ENV['ELASTICSEARCH_URL'] ||
-              ((site.config||{})['elasticsearch']||{})['url'] ||
-              raise(ArgumentError, "No Elasticsearch URL present, skipping indexing")
-
-      # Get the rest of the config options, or use the defaults:
-      @number_of_shards = site.config['elasticsearch']['number_of_shards'] || 1
-      @number_of_replicas = site.config['elasticsearch']['number_of_replicas'] || 1
-      @index_name = site.config['elasticsearch']['index_name'] || "jekyll"
-      @default_type = site.config['elasticsearch']['default_type'] || 'post'
+      @site = site.config
     end
   end
 end

--- a/lib/searchyou/generator.rb
+++ b/lib/searchyou/generator.rb
@@ -2,18 +2,24 @@ require 'searchyou/indexer'
 
 module Searchyou
 
+  # Allow access to Searchyou.configuration hash
+  class << self
+    attr_accessor :configuration
+  end
+
   class Generator < Jekyll::Generator
+
     safe true
     priority :lowest
 
     # Public: Invoked by Jekyll during the generation phase.
     def generate(site)
 
-      # Find the ES URL
-      url = elasticsearch_url(site)
+      # Gather the configuration options
+      Searchyou.configure(site)
 
       # Prepare the indexer
-      indexer = Searchyou::Indexer.new(url)
+      indexer = Searchyou::Indexer.new(Searchyou.configuration.url)
       indexer.start
 
       # Iterate through the site contents and send to indexer
@@ -28,22 +34,37 @@ module Searchyou
       # Signal to the indexer that we're done adding content
       indexer.finish
 
-
     # Handle any exceptions gracefully
     rescue => e
       $stderr.puts "Searchyll: #{e.class.name} - #{e.message}"
+      $stderr.puts "Backtrace: #{e.backtrace.each{|l| puts l};nil}"
       raise(e)
-    end
-
-    # Figure out the Elasticsearch URL, from an environment variable or the
-    # Jekyll site configuration. Raises an exception if none is found, so we
-    # can skip the indexing.
-    def elasticsearch_url(site)
-      ENV['BONSAI_URL'] || ENV['ELASTICSEARCH_URL'] ||
-      ((site.config||{})['elasticsearch']||{})['url'] ||
-      raise(ArgumentError, "No Elasticsearch URL present, skipping indexing")
     end
 
   end
 
+  # Create a configuration for the site
+  def self.configure(site)
+    self.configuration ||= Configuration.new(site)
+  end
+
+  class Configuration
+    attr_accessor :url, :number_of_shards, :number_of_replicas, :index_name, :default_type
+
+    def initialize(site)
+
+      # Figure out the Elasticsearch URL, from an environment variable or the
+      # Jekyll site configuration. Raises an exception if none is found, so we
+      # can skip the indexing.
+      @url = ENV['BONSAI_URL'] || ENV['ELASTICSEARCH_URL'] ||
+              ((site.config||{})['elasticsearch']||{})['url'] ||
+              raise(ArgumentError, "No Elasticsearch URL present, skipping indexing")
+
+      # Get the rest of the config options, or use the defaults:
+      @number_of_shards = site.config['elasticsearch']['number_of_shards'] || 1
+      @number_of_replicas = site.config['elasticsearch']['number_of_replicas'] || 1
+      @index_name = site.config['elasticsearch']['index_name'] || "jekyll"
+      @default_type = site.config['elasticsearch']['default_type'] || 'post'
+    end
+  end
 end

--- a/lib/searchyou/generator.rb
+++ b/lib/searchyou/generator.rb
@@ -2,11 +2,6 @@ require 'searchyou/indexer'
 
 module Searchyou
 
-  # Allow access to Searchyou.configuration hash
-  class << self
-    attr_accessor :configuration
-  end
-
   class Generator < Jekyll::Generator
 
     safe true
@@ -16,10 +11,10 @@ module Searchyou
     def generate(site)
 
       # Gather the configuration options
-      Searchyou.configure(site)
+      configuration = Configuration.new(site)
 
       # Prepare the indexer
-      indexer = Searchyou::Indexer.new(Searchyou.configuration)
+      indexer = Searchyou::Indexer.new(configuration)
       indexer.start
 
       # Iterate through the site contents and send to indexer
@@ -43,16 +38,38 @@ module Searchyou
 
   end
 
-  # Create a configuration for the site
-  def self.configure(site)
-    self.configuration ||= Configuration.new(site)
-  end
-
   # Class containing configuration options
   class Configuration
     attr_accessor :site
     def initialize(site)
-      @site = site.config
+      self.site = site
+    end
+
+    # Determine a URL for the cluster, or fail with error
+    def elasticsearch_url
+      ENV['BONSAI_URL'] || ENV['ELASTICSEARCH_URL'] ||
+        ((site.config||{})['elasticsearch']||{})['url'] ||
+        raise(ArgumentError, "No Elasticsearch URL present, skipping indexing")
+    end
+
+    # Getter for the number of primary shards
+    def elasticsearch_number_of_shards
+      site.config['elasticsearch']['number_of_shards'] || 1
+    end
+
+    # Getter for the number of replicas
+    def elasticsearch_number_of_replicas
+      site.config['elasticsearch']['number_of_replicas'] || 1
+    end
+
+    # Getter for the index name
+    def elasticsearch_index_base_name
+      site.config['elasticsearch']['index_name'] || "jekyll"
+    end
+
+    # Getter for the default type
+    def elasticsearch_default_type
+      site.config['elasticsearch']['default_type'] || 'post'
     end
   end
 end


### PR DESCRIPTION
Applied notes from PR #8 . We're now using a Configuration class to handle user settings and defaults. Tested and verified locally. This PR addresses:

* #4 Create a Configuration class
* #5 Make the base index name configurable 
* #6 Make the number of shards and replicas configurable

