### PR TITLE
fix the 404 error while updating aliases with multiple indices

### DIFF
--- a/lib/searchyll/indexer.rb
+++ b/lib/searchyll/indexer.rb
@@ -244,7 +244,7 @@ module Searchyll
       update_aliases.body = {
         actions: [
           { remove: {
-            index: old_indices.join(','),
+            index: "*",
             alias: configuration.elasticsearch_index_base_name
           } },
           { add: {


### PR DESCRIPTION
Removing the alias on all related indices should be safe and reasonable even with concurrent operations.
This fix should be compatible with Elasticsearch 2.4 and the current version (7.x).