### PR TITLE
fix: add OpenSearch/Elasticsearch 7+ compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ elasticsearch:
     - /news/*
 ```
 
+### ES Auth
+Elasticsearch authentication can be provided both by passing user and password as URI parameter:
+```yaml
+url: https://user:pass@someurl.com
+```
+Or by easily setting those ENV variables:
+```sh
+ELASTICSEARCH_URL=http://localhost:9200/
+ELASTICSEARCH_USER=elastic
+ELASTICSEARCH_UPASS=changeme
+```
+
 ### Custom Settings File Example
 
 It should be written to be plugged into the `settings` slot of a [create index](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html) call

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ elasticsearch:
   default_type: "post"              # Optional. Default type is "post".
   custom_settings: _es_settings.yml # Optional. No default. Relative to your src folder
   custom_mappings: _es_mappings.yml # Optional. No default. Relative to your src folder
+  ignore:                           # Optional. No default.
+    - /news/*
 ```
 
 ### Custom Settings File Example

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> This repository is a fork of https://github.com/omc/searchyll used for indexing the [developers.italia.it](https://github.com/italia/developers.italia.it) website. All the changes were contributed upstream, so when all our [pull requests](https://github.com/omc/searchyll/pulls?utf8=✓&q=is%3Apr+author%3Aalranel+) are merged we can get rid of this fork.
+
 # Searchyll
 
 Search for Jekyll apps. A plugin for indexing your pages into a search engine.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Or by easily setting those ENV variables:
 ```sh
 ELASTICSEARCH_URL=http://localhost:9200/
 ELASTICSEARCH_USER=elastic
-ELASTICSEARCH_UPASS=changeme
+ELASTICSEARCH_PASS=changeme
 ```
 
 ### Custom Settings File Example

--- a/lib/searchyll.rb
+++ b/lib/searchyll.rb
@@ -38,7 +38,7 @@ begin
 
     if (indexer = indexers[page.site])
       indexer << ({
-        "id"   => page.name,
+        "id"   => page.url,
         "url"  => page.url,
         "text" => nokogiri_doc.xpath("//article//text()").to_s.gsub(/\s+/, " ")
       }).merge(page.data)

--- a/lib/searchyll/configuration.rb
+++ b/lib/searchyll/configuration.rb
@@ -69,6 +69,11 @@ module Searchyll
       site.config['elasticsearch']['default_type'] || 'post'
     end
 
+    # Getter for the ignore regex
+    def elasticsearch_ignore
+      site.config['elasticsearch']['ignore'] || []
+    end
+
     # Getter for es mapping
     def elasticsearch_mapping_path
       site.config['elasticsearch']['custom_mappings']

--- a/lib/searchyll/configuration.rb
+++ b/lib/searchyll/configuration.rb
@@ -11,6 +11,12 @@ module Searchyll
       ENV['BONSAI_URL'] || ENV['ELASTICSEARCH_URL'] ||
         ((site.config||{})['elasticsearch']||{})['url']
     end
+    def elasticsearch_user
+      ENV['ELASTICSEARCH_USER']
+    end
+    def elasticsearch_pass
+      ENV['ELASTICSEARCH_PASS']
+    end
 
     def valid?
       elasticsearch_url && !elasticsearch_url.empty? && elasticsearch_url.start_with?('http')

--- a/lib/searchyll/indexer.rb
+++ b/lib/searchyll/indexer.rb
@@ -19,6 +19,8 @@ module Searchyll
     attr_accessor :queue
     attr_accessor :timestamp
     attr_accessor :uri
+    attr_accessor :es_user
+    attr_accessor :es_pass
     attr_accessor :working
     attr_accessor :ignore_regex
 
@@ -27,6 +29,8 @@ module Searchyll
     def initialize(configuration)
       self.configuration = configuration
       self.uri           = URI(configuration.elasticsearch_url)
+      self.es_user       = configuration.elasticsearch_user
+      self.es_pass       = configuration.elasticsearch_pass
       self.queue         = Queue.new
       self.working       = true
       self.timestamp     = Time.now
@@ -159,8 +163,12 @@ module Searchyll
       req = klass.new(path)
       req.content_type = 'application/json'
       req['Accept']    = 'application/json'
-      # Append auth credentials if the exist
-      req.basic_auth(uri.user, uri.password) if uri.user && uri.password
+      # Append auth credentials if they exist
+      # it trying to get them from env and then from
+      # elasticsearch uri itself
+      user = es_user || uri.user
+      pass = es_pass || uri.password
+      req.basic_auth(user, pass) if user && pass
       req
     end
 

--- a/lib/searchyll/indexer.rb
+++ b/lib/searchyll/indexer.rb
@@ -130,8 +130,8 @@ module Searchyll
       }
 
       if configuration.elasticsearch_mapping
-        payload['mappings'] = {}
-        payload['mappings'].store(configuration.elasticsearch_default_type, configuration.elasticsearch_mapping)
+        # OpenSearch/ES 7+ doesn't support type in mappings - use flat structure
+        payload['mappings'] = configuration.elasticsearch_mapping
       end
 
       json_payload = payload.to_json
@@ -177,7 +177,8 @@ module Searchyll
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
     def es_bulk_insert!(http, batch)
       return if batch.empty?
-      bulk_insert = http_post("/#{elasticsearch_index_name}/#{configuration.elasticsearch_default_type}/_bulk")
+      # OpenSearch/ES 7+ doesn't support type in bulk endpoint
+      bulk_insert = http_post("/#{elasticsearch_index_name}/_bulk")
       bulk_insert.content_type = 'application/x-ndjson'
       bulk_insert.body = batch.map do |doc|
         [{ index: {} }.to_json, doc.to_json].join("\n")

--- a/lib/searchyll/indexer.rb
+++ b/lib/searchyll/indexer.rb
@@ -173,7 +173,7 @@ module Searchyll
       bulk_insert.content_type = 'application/x-ndjson'
       bulk_insert.body = batch.map do |doc|
         [{ index: {} }.to_json, doc.to_json].join("\n")
-      end.force_encoding('ascii-8bit').join("\n") + "\n"
+      end.join("\n").force_encoding('ascii-8bit') + "\n"
       res = http.request(bulk_insert)
       if !res.kind_of?(Net::HTTPSuccess)
         $stderr.puts "Elasticsearch returned an error when performing bulk insert: " + res.message + " " + res.body

--- a/lib/searchyll/indexer.rb
+++ b/lib/searchyll/indexer.rb
@@ -221,19 +221,38 @@ module Searchyll
     # hot swap the index into the canonical alias
     def finalize_aliases(http)
       update_aliases = http_post('/_aliases')
+
+      # perform removal and addition in two different calls so that
+      # the second one is performed even if the first one fails
+      if !old_indices.empty?
+        update_aliases.body = {
+          actions: [
+            { remove: {
+              index: old_indices.join(','),
+              alias: configuration.elasticsearch_index_base_name
+            } }
+          ]
+        }.to_json
+        res = http.request(update_aliases)
+        if !res.kind_of?(Net::HTTPSuccess)
+          $stderr.puts "Elasticsearch returned an error when removing old aliases: " + res.message + " " + res.body
+          exit
+        end
+      end
+
       update_aliases.body = {
         actions: [
-          { remove: {
-            index: old_indices.join(','),
-            alias: configuration.elasticsearch_index_base_name
-          } },
           { add: {
             index: elasticsearch_index_name,
             alias: configuration.elasticsearch_index_base_name
           } }
         ]
       }.to_json
-      http.request(update_aliases)
+      res = http.request(update_aliases)
+      if !res.kind_of?(Net::HTTPSuccess)
+        $stderr.puts "Elasticsearch returned an error when assigning the new alias: " + res.message + " " + res.body
+        exit
+      end
     end
 
     # delete old indices after a successful reindexing run

--- a/lib/searchyll/indexer.rb
+++ b/lib/searchyll/indexer.rb
@@ -20,6 +20,7 @@ module Searchyll
     attr_accessor :timestamp
     attr_accessor :uri
     attr_accessor :working
+    attr_accessor :ignore_regex
 
     # Initialize a basic indexer, with a Jekyll site configuration, waiting
     # to be supplied with documents for indexing.
@@ -30,11 +31,19 @@ module Searchyll
       self.working       = true
       self.timestamp     = Time.now
       self.batch_size    = BATCH_SIZE
+      
+      # Compute a regex for detecting paths to ignore
+      escaped = (configuration.elasticsearch_ignore.map {|i| Regexp.escape(i).gsub('\*','.+?')}).join('|')
+      self.ignore_regex = Regexp.new "^(#{escaped})$", Regexp::IGNORECASE
     end
 
     # Public: Add new documents for batch indexing.
     def <<(doc)
-      queue << doc
+      if doc['url'] =~ self.ignore_regex
+        #puts %(        ...ignoring)
+      else
+        queue << doc
+      end
     end
 
     # Public: start the indexer and wait for documents to index.

--- a/lib/searchyll/indexer.rb
+++ b/lib/searchyll/indexer.rb
@@ -251,7 +251,6 @@ module Searchyll
         res = http.request(update_aliases)
         if !res.kind_of?(Net::HTTPSuccess)
           $stderr.puts "Elasticsearch returned an error when removing old aliases: " + res.message + " " + res.body
-          exit
         end
       end
 


### PR DESCRIPTION
## Summary

This PR updates the indexer to be compatible with OpenSearch and Elasticsearch 7+.

## Changes

### 1. Mappings format
**Before:** Mappings were wrapped in a type (deprecated since ES 7):
```json
{"mappings": {"_doc": {"properties": {...}}}}
```

**After:** Flat structure (ES 7+ / OpenSearch compatible):
```json
{"mappings": {"properties": {...}}}
```

### 2. Bulk endpoint
**Before:** Included type in URL (deprecated):
```
POST /{index}/_doc/_bulk
```

**After:** Type-less endpoint (ES 7+ / OpenSearch compatible):
```
POST /{index}/_bulk
```

## Compatibility

- ✅ OpenSearch 1.x, 2.x
- ✅ Elasticsearch 7.x, 8.x
- ❌ Elasticsearch 6.x and earlier (EOL, not supported)

## Related

Needed for https://github.com/italia/developers.italia.it to migrate from Elasticsearch to OpenSearch.